### PR TITLE
doc: Document sw requirements, add make target to install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# --- Configure and deploy ---
 config:
 	jsonnet -S -c -m . config.jsonnet
 
@@ -6,3 +7,30 @@ fmt:
 
 deploy: config
 	firebase deploy
+
+# --- Install software ----
+
+get-tools: get-firebase get-jsonnet  ## Install/update tools needed by this Makefile
+
+fbos = $(fbos_$(shell uname))
+fbos_Linux = linux
+fbos_Dawrin = macos
+fburl = https://github.com/firebase/firebase-tools/releases/latest/download/firebase-tools-$(fbos)
+fbinstall = /usr/local/bin/firebase
+fblatest = $(shell curl -s -o /dev/null -D - '$(fburl)' | awk -F/ '/^location:/ {print $$8}')
+# firebase emits an escape sequence before the version. split on ascii 007 to extract
+# `firebase --version | hexdump -C` to demonstrate
+fbcurrent = v$(or $(shell firebase --version 2> /dev/null | cut -d '' -f 2),0.0.0)
+
+get-firebase:  ## Install/update firebase CLI to $(fbinstall)
+	@if [ "$(fbcurrent)" != "$(fblatest)" ]; then \
+		curl -L -o '$(fbinstall)' '$(fburl)'; \
+		chmod 755 '$(fbinstall)'; \
+	else \
+		echo 'Firebase CLI is already at the latest version'; \
+	fi
+
+jsonnet = github.com/google/go-jsonnet
+# go get is safe because we are not in a go module.
+get-jsonnet:  ## Install/update jsonnet CLI tools
+	go get $(jsonnet)/cmd/jsonnet $(jsonnet)/cmd/jsonnetfmt

--- a/docs/redirection.md
+++ b/docs/redirection.md
@@ -1,0 +1,32 @@
+# Redirection
+
+HTTP and HTML redirection are used to point the `foxygo.at` domain
+appropriately for two purposes: Go modules, and file serving from a git
+repository. Both redirections point to `github.com/foxygoat` but are
+done differently as Go modules require some HTML metadata to be served
+properly. That requires HTML redirection so we can attach that metadata
+before being redirected. The file serving is a more simple HTTP
+redirection to `raw.githubusercontent.com/foxygoat`.
+
+The file [`config.jsonnet`](config.jsonnet) contains a list of both
+redirections and is used to generate the firebase config file
+(`firebase.json`) which contains the HTTP redirections and the
+`index.html` files which contain the HTML Go metadata and redirections.
+
+Generating these files is done through a Makefile, by running:
+
+    make config
+
+`config.jsonnet` also contains the standard firebase config, into which
+the HTTP redirections are added.
+
+HTML redirection is used to redirect Go module references from
+`foxygo.at/<module>` to `github.com/foxygoat/<module>`. A module
+redirection should be set up for each module published under
+`foxygo.at`.
+
+Files redirection is used to redirect repository file access references
+to be able to serve files from a `github.com/foxygoat` repository.
+Currently this is intended to serve jsonnet files for use by
+`foxygo.at/jsonnext/importer`.
+

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,37 @@
+# Project Setup
+
+## DNS Setup
+
+NOTE: DNS is already set up. This documents what was done.
+
+The GCP project hosting the firebase project is `foxygoat-ab0f2` which
+has a custom domain set up as per the [firebase custom domain
+docs](https://firebase.google.com/docs/hosting/custom-domain). To
+implement this, three DNS records were created in the [GoDaddy DNS
+Management for foxygo.at](https://dcc.godaddy.com/manage/foxygo.at/dns):
+
+  * a `TXT` record for google-site-verification
+  * 2 `A` records (151.101.1.195, 151.101.65.195)
+
+In BIND zone format:
+
+    @       3600     IN     A       151.101.1.195
+    @       3600     IN     A       151.101.65.195
+    @       600      IN     TXT     "google-site-verification=<redacted>"
+
+The shorter timeout on the `TXT` record is so if we need to re-create
+it, it will not take too long to propagate. It will be queried
+infrequently (just on setup I assume) so the short expiry should not
+create excessive lookups.
+
+## Firebase setup
+
+NOTE: Firebase is already set up. This documents what was done.
+
+The initial files in this repository have been created using the
+[`firebase` CLI tool](https://firebase.google.com/docs/cli) and running:
+
+    firebase init
+
+The only Firebase product selected was `Hosting`.
+


### PR DESCRIPTION
Document the software requirements to generate and deploy the
configuration and files for the redirections.

Add some targets to the `Makefile` to install these software
requirements for you (`software-update`, `firebase-update` and
`jsonnet-update`).

Closes: #3