### PR TITLE
Add CI / CD with Google Cloud Build

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,0 @@
-{
-  "projects": {
-    "default": "foxygoat-ab0f2"
-  }
-}

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 # --- Configure and deploy ---
-config:
+
+config: fmt ## Generate firebase-hosted files in 'public' folder
 	jsonnet -S -c -m . config.jsonnet
 
-fmt:
+fmt: ## Format jsonnet files
 	jsonnetfmt -i config.jsonnet firebase.libsonnet
 
-deploy: config
-	firebase deploy
+deploy: config  ## Deploy 'public' folder to firebase
+	firebase deploy --only hosting --project foxygoat-ab0f2
 
 # --- Install software ----
 
@@ -22,7 +23,7 @@ fblatest = $(shell curl -s -o /dev/null -D - '$(fburl)' | awk -F/ '/^location:/ 
 # `firebase --version | hexdump -C` to demonstrate
 fbcurrent = v$(or $(shell firebase --version 2> /dev/null | cut -d '' -f 2),0.0.0)
 
-get-firebase:  ## Install/update firebase CLI to $(fbinstall)
+get-firebase:  ## Install/update firebase CLI to /usr/local/bin
 	@if [ "$(fbcurrent)" != "$(fblatest)" ]; then \
 		curl -L -o '$(fbinstall)' '$(fburl)'; \
 		chmod 755 '$(fbinstall)'; \
@@ -32,5 +33,17 @@ get-firebase:  ## Install/update firebase CLI to $(fbinstall)
 
 jsonnet = github.com/google/go-jsonnet
 # go get is safe because we are not in a go module.
-get-jsonnet:  ## Install/update jsonnet CLI tools
+get-jsonnet:  ## Install/update jsonnet CLI tools to $GOPATH/bin
 	go get $(jsonnet)/cmd/jsonnet $(jsonnet)/cmd/jsonnetfmt
+
+# --- Utilities ----
+
+COLOUR_NORMAL = $(shell tput sgr0 2>/dev/null)
+COLOUR_RED    = $(shell tput setaf 1 2>/dev/null)
+COLOUR_GREEN  = $(shell tput setaf 2 2>/dev/null)
+COLOUR_WHITE  = $(shell tput setaf 7 2>/dev/null)
+
+help:
+	@awk -F ':.*## ' 'NF == 2 && $$1 ~ /^[A-Za-z0-9_-]+$$/ { printf "$(COLOUR_WHITE)%-30s$(COLOUR_NORMAL)%s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+
+.PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,17 @@ jsonnet = github.com/google/go-jsonnet
 get-jsonnet:  ## Install/update jsonnet CLI tools to $GOPATH/bin
 	go get $(jsonnet)/cmd/jsonnet $(jsonnet)/cmd/jsonnetfmt
 
+# --- CI ---
+
+DIFF_MSG = $(COLOUR_RED)"generated code is out of date, run 'make config' and commit changes"$(COLOUR_NORMAL)
+check-diff:
+	@BEFORE_HASH=$$(find public -type f -exec shasum {} \; | sort | shasum); \
+	$(MAKE) config; \
+	AFTER_HASH=$$(find public -type f -exec shasum {} \; | sort | shasum); \
+	[ "$${BEFORE_HASH}" = "$${AFTER_HASH}" ] || { printf "$(DIFF_MSG)\n"; exit 1; }
+
+deploy-on-master: $(if $(filter $(BRANCH_NAME),master),deploy)
+
 # --- Builder image for CI ---
 
 builder: ## Create builder image for Google Cloud Build

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,25 @@ jsonnet = github.com/google/go-jsonnet
 get-jsonnet:  ## Install/update jsonnet CLI tools to $GOPATH/bin
 	go get $(jsonnet)/cmd/jsonnet $(jsonnet)/cmd/jsonnetfmt
 
+# --- Builder image for CI ---
+
+builder: ## Create builder image for Google Cloud Build
+	docker build -f build/builder.Dockerfile -t foxygoat/firebase-tools .
+
+push-builder: ## Push builder image to docker hub
+	docker push foxygoat/firebase-tools
+
+FIREBASE_TOKEN_HELP = $(COLOUR_RED)FIREBASE_TOKEN not set, run\n  firebase login:ci\n  export FIREBASE_TOKEN='<token>'\n$(COLOUR_NORMAL)
+
+run-builder: config ## Run builder image locally
+	@[ -n "$${FIREBASE_TOKEN}" ] || { printf "$(FIREBASE_TOKEN_HELP)"; exit 1; }
+	docker run --rm \
+		--volume $(PWD):/workspace \
+		--workdir /workspace \
+		--env FIREBASE_TOKEN \
+		foxygoat/firebase-tools deploy \
+		--only hosting --project foxygoat-ab0f2
+
 # --- Utilities ----
 
 COLOUR_NORMAL = $(shell tput sgr0 2>/dev/null)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # Firebase hosting of https://foxygo.at
 
-The `foxygo.at` domain is used to name Go modules. However it does not
-host those modules, but instead redirects to the code on github.com.
-Firebase is used to do this redirection as it does it easily, cheaply
-(free!) and with TLS.
+The `foxygo.at` domain is used to serve github.com/foxygoat repositories
+as Go modules and raw file content.
+
+It does not host those repositories, but instead redirects to the code
+on github.com. Firebase is used to do this redirection as it does it
+easily, cheaply (free!) and with TLS.
 
 ## Requirements
 
-* GNU make
-* jsonnet and jsonnetfmt
-* Firebase CLI
+- GNU make
+- jsonnet and jsonnetfmt
+- Firebase CLI
 
 GNU make should be installed by default on most systems. If not, install
 it.
@@ -18,42 +20,28 @@ Jsonnet and Firebase can be installed by running:
 
     make get-tools
 
-This will try to install `firebase` in `/usr/local/bin`. If you do not
-have permission to do that, instead run the following commands:
+Without appropriate permissions this might fail, see [docs/get-tools.md]
+for help.
 
-    sudo make get-firebase
-    make get-jsonnet
+## Publish a new repo
 
-The first command will prompt for your password for root access. Do not
-run the `get-jsonnet` target under sudo.
+Edit `config.jsonnet`. If you want to add a new go module add the
+repository name to `go_modules`. If you want to add a new raw GitHub
+file serving repository add the repository name to `go_modules`.
 
-If you don't have sudo access, run:
+Run `make config` and commit changes. The changes will be deployed when
+merged to `master` by our CI/CD system on [Google Cloud Builds](https://console.cloud.google.com/cloud-build/builds?project=foxygoat-ab0f2).
 
-    mkdir -p $HOME/bin
-    make fbinstall=$HOME/bin get-tools
+## Help
 
-and add `$HOME/bin` to your `PATH`.
+Most operations are driven by the `Makefile`, to see them run
 
-## Configuration
+    make help
 
-Configuration of the redirections (and the entire firebase project) is
-generated from the jsonnet. The main config file is `config.jsonnet`
-which contains the Firebase hosting config and the redirections to set
-up.
+## Manual deployment
 
-To generate the config and deployment files from the source config, run:
-
-    make config
-
-If you edit the jsonnet config files, make sure you format them (if your
-editor does not do it automatically) with:
-
-    make fmt
-
-## Deployment
-
-Any changes to the Firebase configuration needs to be deployed. This can
-be done by running:
+Changes are typically deployed by CI / CD pipeline but can be manually
+deployed with
 
     make deploy
 

--- a/build/builder.Dockerfile
+++ b/build/builder.Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:buster as jsonnet
+
+ADD Makefile Makefile
+RUN make get-jsonnet
+
+FROM node:buster
+
+RUN npm i -g firebase-tools
+ADD build/firebase.sh /usr/bin
+RUN chmod +x /usr/bin/firebase.sh
+COPY --from=jsonnet /go/bin/jsonnet /usr/bin
+COPY --from=jsonnet /go/bin/jsonnetfmt /usr/bin
+
+ENTRYPOINT [ "/usr/bin/firebase.sh" ]

--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -1,0 +1,11 @@
+steps:
+- id: 'check-diff'
+  name: foxygoat/firebase-tools
+  entrypoint: 'make'
+  args: ['check-diff']
+
+- id: 'deploy'
+  env: ['BRANCH_NAME=${BRANCH_NAME}']
+  name: foxygoat/firebase-tools
+  entrypoint: 'make'
+  args: ['deploy']

--- a/build/firebase.sh
+++ b/build/firebase.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# run the original firebase
+if [ $FIREBASE_TOKEN ]; then
+  exec firebase "$@" --token $FIREBASE_TOKEN
+else
+  exec firebase "$@"
+fi

--- a/docs/get-tools.md
+++ b/docs/get-tools.md
@@ -1,0 +1,21 @@
+# get-tools
+
+Jsonnet and Firebase can be installed by running:
+
+    make get-tools
+
+This will try to install `firebase` in `/usr/local/bin`. If you do not
+have permission to do that, instead run the following commands:
+
+    sudo make get-firebase
+    make get-jsonnet
+
+The first command will prompt for your password for root access. Do not
+run the `get-jsonnet` target under sudo.
+
+If you don't have sudo access, run:
+
+    mkdir -p $HOME/bin
+    make fbinstall=$HOME/bin get-tools
+
+and add `$HOME/bin` to your `PATH`.


### PR DESCRIPTION
Add CI step of checking that generated configs are up-to-date and add a
CD step to deploy config.

Cleanup docs and Makefile.

Closes #2 